### PR TITLE
fix: internal review

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@commitlint/cli": "19.3.0",
     "@commitlint/config-conventional": "19.2.2",
     "@defi-wonderland/natspec-smells": "1.1.6",
-    "@defi-wonderland/xerc20": "github:defi-wonderland/xerc20#7e110fa3418ff205f111c520f0ee33aa67fc499f",
+    "@defi-wonderland/xerc20": "github:defi-wonderland/xerc20#8929d60c02671373a73c72c8d98c845a596b7b08",
     "forge-std": "github:foundry-rs/forge-std#1.9.2",
     "husky": ">=9",
     "lint-staged": ">=10",

--- a/script/CrosschainERC20WithLockboxDeploy.s.sol
+++ b/script/CrosschainERC20WithLockboxDeploy.s.sol
@@ -17,7 +17,6 @@ contract DeployCrosschainERC20WithLockbox is Script {
   struct DeploymentParams {
     string _name;
     string _symbol;
-    uint8 _decimals;
     uint256[] _minterLimits;
     uint256[] _burnerLimits;
     address[] _bridges;
@@ -49,7 +48,6 @@ contract DeployCrosschainERC20WithLockbox is Script {
     _deploymentParams[1] = DeploymentParams({
       _name: 'Test',
       _symbol: 'TST',
-      _decimals: 18,
       _minterLimits: minterLimits,
       _burnerLimits: burnerLimits,
       _bridges: bridges,
@@ -65,7 +63,6 @@ contract DeployCrosschainERC20WithLockbox is Script {
     (address _crosschainERC20Address, address _lockboxAddress) = _factory.deployCrosschainERC20WithLockbox(
       _params._name,
       _params._symbol,
-      _params._decimals,
       _params._minterLimits,
       _params._burnerLimits,
       _params._bridges,

--- a/src/contracts/CrosschainERC20Factory.sol
+++ b/src/contracts/CrosschainERC20Factory.sol
@@ -24,8 +24,8 @@ contract CrosschainERC20Factory is ICrosschainERC20Factory {
     uint256[] memory _burnerLimits,
     address[] memory _bridges,
     address _owner
-  ) external returns (address crosschainERC20_) {
-    crosschainERC20_ = _deployCrosschainERC20(_name, _symbol, _decimals, _minterLimits, _burnerLimits, _bridges, _owner);
+  ) external returns (address _crosschainERC20) {
+    _crosschainERC20 = _deployCrosschainERC20(_name, _symbol, _decimals, _minterLimits, _burnerLimits, _bridges, _owner);
   }
 
   /// @inheritdoc ICrosschainERC20Factory
@@ -38,14 +38,14 @@ contract CrosschainERC20Factory is ICrosschainERC20Factory {
     address[] memory _bridges,
     address _baseToken,
     address _owner
-  ) external returns (address crosschainERC20_, address crosschainERC20Lockbox_) {
-    crosschainERC20_ = _deployCrosschainERC20(_name, _symbol, _decimals, _minterLimits, _burnerLimits, _bridges, _owner);
-    crosschainERC20Lockbox_ = _deployLockbox(crosschainERC20_, _baseToken);
+  ) external returns (address _crosschainERC20, address _crosschainERC20Lockbox) {
+    _crosschainERC20 = _deployCrosschainERC20(_name, _symbol, _decimals, _minterLimits, _burnerLimits, _bridges, _owner);
+    _crosschainERC20Lockbox = _deployLockbox(_crosschainERC20, _baseToken);
   }
 
   /// @inheritdoc ICrosschainERC20Factory
-  function deployERC7802Adapter(address _xerc20, address _bridge) external returns (address erc7802Adapter_) {
-    erc7802Adapter_ = _deployERC7802Adapter(_xerc20, _bridge);
+  function deployERC7802Adapter(address _xerc20, address _bridge) external returns (address _erc7802Adapter) {
+    _erc7802Adapter = _deployERC7802Adapter(_xerc20, _bridge);
   }
 
   /// @notice Deploys a new CrosschainERC20 contract and returns the address
@@ -56,7 +56,7 @@ contract CrosschainERC20Factory is ICrosschainERC20Factory {
   /// @param _burnerLimits The burner limits for the token
   /// @param _bridges The bridges for the token
   /// @param _owner The owner of the new token
-  /// @return crosschainERC20_ The address of the new CrosschainERC20 contract
+  /// @return _crosschainERC20 The address of the new CrosschainERC20 contract
   function _deployCrosschainERC20(
     string memory _name,
     string memory _symbol,
@@ -65,7 +65,7 @@ contract CrosschainERC20Factory is ICrosschainERC20Factory {
     uint256[] memory _burnerLimits,
     address[] memory _bridges,
     address _owner
-  ) internal returns (address crosschainERC20_) {
+  ) internal returns (address _crosschainERC20) {
     uint256 _bridgesLength = _bridges.length;
 
     if (_minterLimits.length != _bridgesLength || _burnerLimits.length != _bridgesLength) revert InvalidLength();
@@ -74,38 +74,38 @@ contract CrosschainERC20Factory is ICrosschainERC20Factory {
     bytes memory creation = type(CrosschainERC20).creationCode;
     bytes memory bytecode = abi.encodePacked(creation, abi.encode(_name, _symbol, _decimals, address(this)));
 
-    crosschainERC20_ = CREATE3.deployDeterministic(bytecode, salt);
+    _crosschainERC20 = CREATE3.deployDeterministic(bytecode, salt);
 
     for (uint256 _i; _i < _bridgesLength; ++_i) {
-      CrosschainERC20(crosschainERC20_).setLimits(_bridges[_i], _minterLimits[_i], _burnerLimits[_i]);
+      CrosschainERC20(_crosschainERC20).setLimits(_bridges[_i], _minterLimits[_i], _burnerLimits[_i]);
     }
 
-    CrosschainERC20(crosschainERC20_).transferOwnership(_owner);
+    CrosschainERC20(_crosschainERC20).transferOwnership(_owner);
   }
 
   /// @notice Deploys a new CrosschainERC20Lockbox contract
   /// @param _crosschainERC20 The address of the CrosschainERC20 contract
   /// @param _baseToken The address of the base token
-  /// @return lockbox_ The address of the new CrosschainERC20Lockbox contract
-  function _deployLockbox(address _crosschainERC20, address _baseToken) internal returns (address payable lockbox_) {
+  /// @return _lockbox The address of the new CrosschainERC20Lockbox contract
+  function _deployLockbox(address _crosschainERC20, address _baseToken) internal returns (address payable _lockbox) {
     bytes32 salt = keccak256(abi.encodePacked(_crosschainERC20, _baseToken, msg.sender));
     bytes memory creation = type(XERC20Lockbox).creationCode;
     bytes memory bytecode = abi.encodePacked(creation, abi.encode(_crosschainERC20, _baseToken, false));
 
-    lockbox_ = payable(CREATE3.deployDeterministic(bytecode, salt));
+    _lockbox = payable(CREATE3.deployDeterministic(bytecode, salt));
 
-    CrosschainERC20(_crosschainERC20).setLockbox(address(lockbox_));
+    CrosschainERC20(_crosschainERC20).setLockbox(address(_lockbox));
   }
 
   /// @notice Deploys a new ERC7802Adapter
   /// @param _xerc20 The address of the xERC20 contract
   /// @param _bridge The address of the bridge
-  /// @return erc7802Adapter_ The address of the new ERC7802Adapter contract
-  function _deployERC7802Adapter(address _xerc20, address _bridge) internal returns (address erc7802Adapter_) {
+  /// @return _erc7802Adapter The address of the new ERC7802Adapter contract
+  function _deployERC7802Adapter(address _xerc20, address _bridge) internal returns (address _erc7802Adapter) {
     bytes32 salt = keccak256(abi.encodePacked(_xerc20, _bridge, msg.sender));
     bytes memory creation = type(ERC7802Adapter).creationCode;
     bytes memory bytecode = abi.encodePacked(creation, abi.encode(_xerc20, _bridge));
 
-    erc7802Adapter_ = CREATE3.deployDeterministic(bytecode, salt);
+    _erc7802Adapter = CREATE3.deployDeterministic(bytecode, salt);
   }
 }

--- a/src/contracts/CrosschainERC20Factory.sol
+++ b/src/contracts/CrosschainERC20Factory.sol
@@ -81,6 +81,8 @@ contract CrosschainERC20Factory is ICrosschainERC20Factory {
     }
 
     CrosschainERC20(_crosschainERC20).transferOwnership(_owner);
+
+    emit CrosschainERC20Deployed(_crosschainERC20);
   }
 
   /// @notice Deploys a new CrosschainERC20Lockbox contract
@@ -95,6 +97,8 @@ contract CrosschainERC20Factory is ICrosschainERC20Factory {
     _lockbox = payable(CREATE3.deployDeterministic(bytecode, salt));
 
     CrosschainERC20(_crosschainERC20).setLockbox(address(_lockbox));
+
+    emit CrosschainERC20LockboxDeployed(_lockbox);
   }
 
   /// @notice Deploys a new ERC7802Adapter
@@ -107,5 +111,7 @@ contract CrosschainERC20Factory is ICrosschainERC20Factory {
     bytes memory bytecode = abi.encodePacked(creation, abi.encode(_xerc20, _bridge));
 
     _erc7802Adapter = CREATE3.deployDeterministic(bytecode, salt);
+
+    emit ERC7802AdapterDeployed(_erc7802Adapter);
   }
 }

--- a/src/contracts/CrosschainERC20Factory.sol
+++ b/src/contracts/CrosschainERC20Factory.sol
@@ -72,7 +72,7 @@ contract CrosschainERC20Factory is ICrosschainERC20Factory {
 
     if (_minterLimits.length != _bridgesLength || _burnerLimits.length != _bridgesLength) revert InvalidLength();
 
-    bytes32 salt = keccak256(abi.encodePacked(_name, _symbol, _decimals, msg.sender));
+    bytes32 salt = keccak256(abi.encode(_name, _symbol, _decimals, msg.sender));
     bytes memory creation = type(CrosschainERC20).creationCode;
     bytes memory bytecode = abi.encodePacked(creation, abi.encode(_name, _symbol, _decimals, address(this)));
 
@@ -92,7 +92,7 @@ contract CrosschainERC20Factory is ICrosschainERC20Factory {
   /// @param _baseToken The address of the base token
   /// @return _lockbox The address of the new CrosschainERC20Lockbox contract
   function _deployLockbox(address _crosschainERC20, address _baseToken) internal returns (address payable _lockbox) {
-    bytes32 salt = keccak256(abi.encodePacked(_crosschainERC20, _baseToken, msg.sender));
+    bytes32 salt = keccak256(abi.encode(_crosschainERC20, _baseToken, msg.sender));
     bytes memory creation = type(XERC20Lockbox).creationCode;
     bytes memory bytecode = abi.encodePacked(creation, abi.encode(_crosschainERC20, _baseToken, false));
 
@@ -108,7 +108,7 @@ contract CrosschainERC20Factory is ICrosschainERC20Factory {
   /// @param _bridge The address of the bridge
   /// @return _erc7802Adapter The address of the new ERC7802Adapter contract
   function _deployERC7802Adapter(address _xerc20, address _bridge) internal returns (address _erc7802Adapter) {
-    bytes32 salt = keccak256(abi.encodePacked(_xerc20, _bridge, msg.sender));
+    bytes32 salt = keccak256(abi.encode(_xerc20, _bridge, msg.sender));
     bytes memory creation = type(ERC7802Adapter).creationCode;
     bytes memory bytecode = abi.encodePacked(creation, abi.encode(_xerc20, _bridge));
 

--- a/src/contracts/CrosschainERC20Factory.sol
+++ b/src/contracts/CrosschainERC20Factory.sol
@@ -5,6 +5,7 @@ pragma solidity 0.8.25;
 import {XERC20Lockbox} from '@xERC20/contracts/XERC20Lockbox.sol';
 import {CrosschainERC20} from 'contracts/CrosschainERC20.sol';
 import {ERC7802Adapter} from 'contracts/ERC7802Adapter.sol';
+import {ERC20} from 'solady/tokens/ERC20.sol';
 
 // Interfaces
 import {ICrosschainERC20Factory} from 'interfaces/ICrosschainERC20Factory.sol';
@@ -32,13 +33,14 @@ contract CrosschainERC20Factory is ICrosschainERC20Factory {
   function deployCrosschainERC20WithLockbox(
     string memory _name,
     string memory _symbol,
-    uint8 _decimals,
     uint256[] memory _minterLimits,
     uint256[] memory _burnerLimits,
     address[] memory _bridges,
     address _baseToken,
     address _owner
   ) external returns (address crosschainERC20_, address crosschainERC20Lockbox_) {
+    uint8 _decimals = ERC20(_baseToken).decimals();
+
     crosschainERC20_ = _deployCrosschainERC20(_name, _symbol, _decimals, _minterLimits, _burnerLimits, _bridges, _owner);
     crosschainERC20Lockbox_ = _deployLockbox(crosschainERC20_, _baseToken);
   }

--- a/src/interfaces/ICrosschainERC20Factory.sol
+++ b/src/interfaces/ICrosschainERC20Factory.sol
@@ -16,7 +16,7 @@ interface ICrosschainERC20Factory {
    * @param _burnerLimits The burner limits for the token
    * @param _bridges The bridges for the token
    * @param _owner The owner of the new token
-   * @return crosschainERC20_ The address of the new CrosschainERC20 contract
+   * @return _crosschainERC20 The address of the new CrosschainERC20 contract
    */
   function deployCrosschainERC20(
     string memory _name,
@@ -26,7 +26,7 @@ interface ICrosschainERC20Factory {
     uint256[] memory _burnerLimits,
     address[] memory _bridges,
     address _owner
-  ) external returns (address crosschainERC20_);
+  ) external returns (address _crosschainERC20);
 
   /**
    * @notice Deploys a new CrosschainERC20Lockbox and CrosschainERC20
@@ -38,8 +38,8 @@ interface ICrosschainERC20Factory {
    * @param _bridges The bridges for the token
    * @param _baseToken The address of the base token
    * @param _owner The owner of the new token
-   * @return crosschainERC20_ The address of the new CrosschainERC20 contract
-   * @return crosschainERC20Lockbox_ The address of the new crosschainERC20Lockbox contract
+   * @return _crosschainERC20 The address of the new CrosschainERC20 contract
+   * @return _crosschainERC20Lockbox The address of the new crosschainERC20Lockbox contract
    */
   function deployCrosschainERC20WithLockbox(
     string memory _name,
@@ -50,13 +50,13 @@ interface ICrosschainERC20Factory {
     address[] memory _bridges,
     address _baseToken,
     address _owner
-  ) external returns (address crosschainERC20_, address crosschainERC20Lockbox_);
+  ) external returns (address _crosschainERC20, address _crosschainERC20Lockbox);
 
   /**
    * @notice Deploys a new ERC7802Adapter
    * @param _xerc20 The address of the xERC20 contract
    * @param _bridge The address of the bridge
-   * @return erc7802Adapter_ The address of the new ERC7802Adapter contract
+   * @return _erc7802Adapter The address of the new ERC7802Adapter contract
    */
-  function deployERC7802Adapter(address _xerc20, address _bridge) external returns (address erc7802Adapter_);
+  function deployERC7802Adapter(address _xerc20, address _bridge) external returns (address _erc7802Adapter);
 }

--- a/src/interfaces/ICrosschainERC20Factory.sol
+++ b/src/interfaces/ICrosschainERC20Factory.sol
@@ -32,7 +32,6 @@ interface ICrosschainERC20Factory {
    * @notice Deploys a new CrosschainERC20Lockbox and CrosschainERC20
    * @param _name The name of the token
    * @param _symbol The symbol of the token
-   * @param _decimals The decimals of the token
    * @param _minterLimits The minter limits for the token
    * @param _burnerLimits The burner limits for the token
    * @param _bridges The bridges for the token
@@ -44,7 +43,6 @@ interface ICrosschainERC20Factory {
   function deployCrosschainERC20WithLockbox(
     string memory _name,
     string memory _symbol,
-    uint8 _decimals,
     uint256[] memory _minterLimits,
     uint256[] memory _burnerLimits,
     address[] memory _bridges,

--- a/src/interfaces/ICrosschainERC20Factory.sol
+++ b/src/interfaces/ICrosschainERC20Factory.sol
@@ -4,6 +4,15 @@ pragma solidity ^0.8.23;
 /// @title ICrosschainERC20Factory
 /// @notice This interface is available on the CrosschainERC20Factory contract.
 interface ICrosschainERC20Factory {
+  /// @notice Emitted when a new CrosschainERC20 contract is deployed.
+  event CrosschainERC20Deployed(address indexed _crosschainERC20);
+
+  /// @notice Emitted when a new CrosschainERC20Lockbox contract is deployed.
+  event CrosschainERC20LockboxDeployed(address indexed _crosschainERC20Lockbox);
+
+  /// @notice Emitted when a new ERC7802Adapter contract is deployed.
+  event ERC7802AdapterDeployed(address indexed _erc7802Adapter);
+
   /// @notice Thrown when minter limits, burner limits, or bridges arrays have mismatched lengths.
   error InvalidLength();
 

--- a/src/interfaces/IERC7802Adapter.sol
+++ b/src/interfaces/IERC7802Adapter.sol
@@ -10,11 +10,11 @@ import {IERC7802} from 'interfaces/external/IERC7802.sol';
 interface IERC7802Adapter is IERC7802 {
   /// @notice Thrown when the caller is not the bridge.
   error Unauthorized();
+
   /**
    * @notice Returns the xERC20 contract.
    * @return _xerc20 The xERC20 contract.
    */
-
   function XERC20() external view returns (IXERC20 _xerc20);
 
   /**

--- a/test/unit/CrosschainERC20.t.sol
+++ b/test/unit/CrosschainERC20.t.sol
@@ -165,7 +165,7 @@ contract UnitCrosschainERC20 is Test {
     vm.assume(_bridge != _ZERO_ADDRESS);
 
     // Bound `amount` to not surpass the xERC20 limits
-    _amount = bound(_amount, 0, 1e40);
+    _amount = bound(_amount, 1, 1e40);
 
     // Set the limits for the Token Bridge
     vm.prank(_OWNER);
@@ -188,7 +188,7 @@ contract UnitCrosschainERC20 is Test {
     vm.assume(_bridge != _ZERO_ADDRESS && _bridge != _PERMIT2);
 
     // Bound `amount` to not surpass the xERC20 limits
-    _amount = bound(_amount, 0, 1e40);
+    _amount = bound(_amount, 1, 1e40);
 
     // Set the limits for the Token Bridge
     vm.prank(_OWNER);

--- a/test/unit/CrosschainERC20Factory.t.sol
+++ b/test/unit/CrosschainERC20Factory.t.sol
@@ -10,6 +10,7 @@ import {XERC20Lockbox} from '@xERC20/contracts/XERC20Lockbox.sol';
 import {CrosschainERC20} from 'contracts/CrosschainERC20.sol';
 import {CrosschainERC20Factory} from 'contracts/CrosschainERC20Factory.sol';
 import {ERC7802Adapter} from 'contracts/ERC7802Adapter.sol';
+import {ERC20} from 'solady/tokens/ERC20.sol';
 
 // Interfaces
 import {ICrosschainERC20Factory} from 'interfaces/ICrosschainERC20Factory.sol';
@@ -158,6 +159,9 @@ contract UnitCrosschainERC20Factory is Test {
     address _crosschainERC20Lockbox;
     address _baseToken = address(makeAddr('ERC20'));
 
+    vm.mockCall(_baseToken, abi.encodeCall(ERC20.decimals, ()), abi.encode(_DECIMALS));
+    vm.expectCall(_baseToken, abi.encodeCall(ERC20.decimals, ()));
+
     // Deploy the CrosschainERC20 with Lockbox
     (_crosschainERC20, _crosschainERC20Lockbox) = _factory.deployCrosschainERC20WithLockbox(
       _name, _symbol, _DECIMALS, _minterLimits, _burnerLimits, _bridges, _baseToken, _owner
@@ -170,7 +174,7 @@ contract UnitCrosschainERC20Factory is Test {
     assertGt(_crosschainERC20Lockbox.code.length, 0);
 
     // Assert the Base Token is set
-    assertEq(address(XERC20Lockbox(payable(_crosschainERC20Lockbox)).ERC20()), _baseToken);
+    assertEq(address(XERC20Lockbox(payable(_crosschainERC20Lockbox)).BASE_TOKEN()), _baseToken);
 
     // Assert the CrosschainERC20 is set
     assertEq(address(XERC20Lockbox(payable(_crosschainERC20Lockbox)).XERC20()), _crosschainERC20);
@@ -192,6 +196,9 @@ contract UnitCrosschainERC20Factory is Test {
     address _crosschainERC20;
     address _crosschainERC20Lockbox;
     address _baseToken = address(makeAddr('ERC20'));
+
+    vm.mockCall(_baseToken, abi.encodeCall(ERC20.decimals, ()), abi.encode(_DECIMALS));
+    vm.expectCall(_baseToken, abi.encodeCall(ERC20.decimals, ()));
 
     // Deploy the CrosschainERC20 with Lockbox
     (_crosschainERC20, _crosschainERC20Lockbox) = _factory.deployCrosschainERC20WithLockbox(

--- a/test/unit/CrosschainERC20Factory.t.sol
+++ b/test/unit/CrosschainERC20Factory.t.sol
@@ -11,6 +11,7 @@ import {CrosschainERC20} from 'contracts/CrosschainERC20.sol';
 import {CrosschainERC20Factory} from 'contracts/CrosschainERC20Factory.sol';
 import {ERC7802Adapter} from 'contracts/ERC7802Adapter.sol';
 import {ERC20} from 'solady/tokens/ERC20.sol';
+import {CREATE3} from 'solady/utils/CREATE3.sol';
 
 // Interfaces
 import {ICrosschainERC20Factory} from 'interfaces/ICrosschainERC20Factory.sol';
@@ -77,6 +78,26 @@ contract UnitCrosschainERC20Factory is Test {
 
     // Deploy the CrosschainERC20
     vm.expectRevert(ICrosschainERC20Factory.InvalidLength.selector);
+    _factory.deployCrosschainERC20(_name, _symbol, _DECIMALS, _minterLimits, _burnerLimits, _bridges, _owner);
+  }
+
+  /// @notice Test that the deployCrosschainERC20 function succeeds.
+  /// @param _minterLimit The minter limit.
+  /// @param _burnerLimit The burner limit.
+  function test_DeployCrosschainERC20RevertsWhenAddressIsTaken(uint256 _minterLimit, uint256 _burnerLimit) public {
+    // Bound limits in allowed range
+    _minterLimit = bound(_minterLimit, 1, type(uint256).max >> 1);
+    _burnerLimit = bound(_burnerLimit, 1, type(uint256).max >> 1);
+
+    // Get the bridges with limits
+    (address[] memory _bridges, uint256[] memory _minterLimits, uint256[] memory _burnerLimits) =
+      _getBridgesWithLimits(_minterLimit, _burnerLimit);
+
+    // Deploy the CrosschainERC20
+    _factory.deployCrosschainERC20(_name, _symbol, _DECIMALS, _minterLimits, _burnerLimits, _bridges, _owner);
+
+    // Deploy the CrosschainERC20 again
+    vm.expectRevert(CREATE3.DeploymentFailed.selector);
     _factory.deployCrosschainERC20(_name, _symbol, _DECIMALS, _minterLimits, _burnerLimits, _bridges, _owner);
   }
 

--- a/test/unit/CrosschainERC20Factory.t.sol
+++ b/test/unit/CrosschainERC20Factory.t.sol
@@ -162,9 +162,12 @@ contract UnitCrosschainERC20Factory is Test {
     vm.mockCall(_baseToken, abi.encodeCall(ERC20.decimals, ()), abi.encode(_DECIMALS));
     vm.expectCall(_baseToken, abi.encodeCall(ERC20.decimals, ()));
 
+    vm.mockCall(_baseToken, abi.encodeCall(ERC20.decimals, ()), abi.encode(_DECIMALS));
+    vm.expectCall(_baseToken, abi.encodeCall(ERC20.decimals, ()));
+
     // Deploy the CrosschainERC20 with Lockbox
     (_crosschainERC20, _crosschainERC20Lockbox) = _factory.deployCrosschainERC20WithLockbox(
-      _name, _symbol, _DECIMALS, _minterLimits, _burnerLimits, _bridges, _baseToken, _owner
+      _name, _symbol, _minterLimits, _burnerLimits, _bridges, _baseToken, _owner
     );
 
     // Assert the CrosschainERC20 is deployed
@@ -200,9 +203,12 @@ contract UnitCrosschainERC20Factory is Test {
     vm.mockCall(_baseToken, abi.encodeCall(ERC20.decimals, ()), abi.encode(_DECIMALS));
     vm.expectCall(_baseToken, abi.encodeCall(ERC20.decimals, ()));
 
+    vm.mockCall(_baseToken, abi.encodeCall(ERC20.decimals, ()), abi.encode(_DECIMALS));
+    vm.expectCall(_baseToken, abi.encodeCall(ERC20.decimals, ()));
+
     // Deploy the CrosschainERC20 with Lockbox
     (_crosschainERC20, _crosschainERC20Lockbox) = _factory.deployCrosschainERC20WithLockbox(
-      _name, _symbol, _DECIMALS, _minterLimits, _burnerLimits, _bridges, _baseToken, _owner
+      _name, _symbol, _minterLimits, _burnerLimits, _bridges, _baseToken, _owner
     );
 
     // Assert the CrosschainERC20Lockbox is set

--- a/yarn.lock
+++ b/yarn.lock
@@ -190,9 +190,9 @@
     solc-typed-ast "18.2.4"
     yargs "17.7.2"
 
-"@defi-wonderland/xerc20@github:defi-wonderland/xerc20#7e110fa3418ff205f111c520f0ee33aa67fc499f":
+"@defi-wonderland/xerc20@github:defi-wonderland/xerc20#8929d60c02671373a73c72c8d98c845a596b7b08":
   version "1.0.1"
-  resolved "https://codeload.github.com/defi-wonderland/xerc20/tar.gz/7e110fa3418ff205f111c520f0ee33aa67fc499f"
+  resolved "https://codeload.github.com/defi-wonderland/xerc20/tar.gz/8929d60c02671373a73c72c8d98c845a596b7b08"
 
 "@noble/curves@1.3.0", "@noble/curves@~1.3.0":
   version "1.3.0"


### PR DESCRIPTION
[[L-2] Lack of safety check to prevent different decimals when deploying](https://github.com/defi-wonderland/crosschainERC20/pull/13/files)
[[L-4] Possible salt collision during deployment](https://github.com/defi-wonderland/crosschainERC20/pull/16/files)
[[I-1] Misc/Typos/Natspec](https://github.com/defi-wonderland/crosschainERC20/pull/15/files)
[[I-9] Missing test](https://github.com/defi-wonderland/crosschainERC20/pull/14/files)

Not including "[L-0] Lack of zero check for _baseToken when _deployLockbox" because of the added check in [lockbox's constructor](https://github.com/defi-wonderland/xERC20/pull/30/commits/8929d60c02671373a73c72c8d98c845a596b7b08)