### PR TITLE
Remove duplicate interface functions

### DIFF
--- a/src/interfaces/ICrosschainERC20.sol
+++ b/src/interfaces/ICrosschainERC20.sol
@@ -7,14 +7,4 @@ import {IERC7802} from 'interfaces/external/IERC7802.sol';
 
 /// @title ICrosschainERC20
 /// @notice This interface is available on the CrosschainERC20 contract.
-interface ICrosschainERC20 is IXERC20, IERC7802 {
-  /// @notice Allows a bridge to mint tokens.
-  /// @param _to     Address to mint tokens to.
-  /// @param _amount Amount of tokens to mint.
-  function crosschainMint(address _to, uint256 _amount) external;
-
-  /// @notice Allows a bridge to burn tokens.
-  /// @param _from   Address to burn tokens from.
-  /// @param _amount Amount of tokens to burn.
-  function crosschainBurn(address _from, uint256 _amount) external;
-}
+interface ICrosschainERC20 is IXERC20, IERC7802 {}

--- a/test/unit/CrosschainERC20Factory.t.sol
+++ b/test/unit/CrosschainERC20Factory.t.sol
@@ -198,7 +198,7 @@ contract UnitCrosschainERC20Factory is Test {
     assertGt(_crosschainERC20Lockbox.code.length, 0);
 
     // Assert the Base Token is set
-    assertEq(address(XERC20Lockbox(payable(_crosschainERC20Lockbox)).BASE_TOKEN()), _baseToken);
+    assertEq(address(XERC20Lockbox(payable(_crosschainERC20Lockbox)).ERC20()), _baseToken);
 
     // Assert the CrosschainERC20 is set
     assertEq(address(XERC20Lockbox(payable(_crosschainERC20Lockbox)).XERC20()), _crosschainERC20);


### PR DESCRIPTION
- remove duplicate functions in ICrosschainERC20
- fix test_DeployCrosschainERC20WithLockboxSucceeds